### PR TITLE
Package Version moved to __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,22 +108,11 @@ htmlcov
 
 *.egg-info
 
-Dockerfile-e
-Makefile-e
-.!*
-requirements.txt
-coverage_html_report
 dist
 _static/
 _templates/
 mongo/
 
-magen-py.tgz
-base_docker_image/magen_datastore-*.whl
-base_docker_image/magen_logger-*.whl
-base_docker_image/magen_mongo-*.whl
-base_docker_image/magen_rest_service-*.whl
-base_docker_image/magen_statistics_service-*.whl
-base_docker_image/magen_utils-*.whl
-base_docker_image/magen_id_client-*.whl
+base_docker_image/*.whl
+base_docker_image/magen_requirements.txt
 base_docker_image/pip.conf

--- a/base_docker_image/Dockerfile
+++ b/base_docker_image/Dockerfile
@@ -30,25 +30,8 @@ RUN pip install --upgrade pip
 
 WORKDIR /tmp
 
-ADD magen_logger-1.0a1-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_logger-1.0a1-py3-none-any.whl
-
-ADD magen_datastore-1.0a1-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_datastore-1.0a1-py3-none-any.whl
-
-ADD magen_utils-1.2a2-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_utils-1.2a2-py3-none-any.whl
-
-ADD magen_mongo-1.0a1-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_mongo-1.0a1-py3-none-any.whl
-
-ADD magen_rest_service-1.2a2-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_rest_service-1.2a2-py3-none-any.whl
-
-ADD magen_statistics_service-1.0a1-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_statistics_service-1.0a1-py3-none-any.whl
-
-ADD magen_id_client-1.1a1-py3-none-any.whl /tmp
-RUN pip3 install /tmp/magen_id_client-1.1a1-py3-none-any.whl
+ADD magen*.whl /tmp/
+COPY magen_requirements.txt /tmp
+RUN pip3 install -r magen_requirements.txt
 
 # ADD pip.conf /etc

--- a/base_docker_image/docker_build.sh
+++ b/base_docker_image/docker_build.sh
@@ -7,15 +7,31 @@ MAGEN=`cd .. && pwd`
 
 cd ${MAGEN}
 
-cp magen_logaru/dist/magen_logger-1.0a1-py3-none-any.whl ${path}
-cp magen_utils/dist/magen_utils-1.2a2-py3-none-any.whl ${path}
-cp magen_datastore/dist/magen_datastore-1.0a1-py3-none-any.whl ${path}
-cp magen_rest/dist/magen_rest_service-1.2a2-py3-none-any.whl ${path}
-cp magen_stats/dist/magen_statistics_service-1.0a1-py3-none-any.whl ${path}
-cp magen_mongo/dist/magen_mongo-1.0a1-py3-none-any.whl ${path}
-cp magen_id_client/dist/magen_id_client-1.1a1-py3-none-any.whl ${path}
+requirements_filename=magen_requirements.txt
+
+number_of_packages=7
+
+# names of folders where magen packages are stored
+folders=(magen_logaru magen_utils magen_datastore magen_rest magen_stats magen_mongo magen_id_client)
+# names of magen packages
+packages=(magen_logger magen_utils magen_datastore magen_rest_service magen_statistics_service magen_mongo magen_id_client)
+
+for ((i=0; i<${number_of_packages}; i++))
+do
+    echo "Copying [${folders[i]}] to docker folder"
+    # cd to package folder and get package version
+    cd ${MAGEN}/${folders[i]}
+    package_version=`python3 -c 'import __init__ as version; print(version.__version__)'`
+    wheel_file=${packages[i]}-${package_version}-py3-none-any.whl
+    # Creating requirements file with correct versions
+    [ ${i} -eq 0 ] && echo ${wheel_file} > ${path}/${requirements_filename} || echo ${wheel_file} >> ${path}/${requirements_filename}
+    # creating a path to wheel file, ex: magen_logaru/dist/magen_logger-1.0a1-py3-none-any.whl
+    wheel_path=${folders[i]}/dist/${wheel_file}
+    # make sure we're in root of the project
+    cd ${MAGEN}
+    # copying wheel into docker folder
+    cp ${wheel_path} ${path}
+done
 # cp pip.conf ${path}
-
 cd ${path}
-
 docker build -t magen_base:17.02 .

--- a/magen_datastore/Makefile
+++ b/magen_datastore/Makefile
@@ -1,4 +1,5 @@
-WHEEL := magen_datastore-1.0a1-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_datastore-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_datastore
 
 include ../common.mk

--- a/magen_datastore/__init__.py
+++ b/magen_datastore/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-datastore"""
+__version__ = '1.0a1'

--- a/magen_datastore/setup.py
+++ b/magen_datastore/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 import sys
 import pip
+import os
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,7 +15,7 @@ if pip_version < 901:
 
 setup(
     name='magen_datastore',
-    version='1.0a1',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     # packages=['container_test', 'ingestion_apis',
     #          'ingestion_server'],

--- a/magen_id_client/Makefile
+++ b/magen_id_client/Makefile
@@ -1,6 +1,7 @@
-WHEEL := magen_id_client-1.1a1-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_id_client-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_id_client
-SPHINX_DIR=docs
+SPHINX_DIR = docs
 
 DOC_PACKAGES = magen_id_client_apis tests
 

--- a/magen_id_client/__init__.py
+++ b/magen_id_client/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-id-client"""
+__version__ = '1.1a1'

--- a/magen_id_client/setup.py
+++ b/magen_id_client/setup.py
@@ -1,8 +1,22 @@
 from setuptools import setup, find_packages
+import os
+import sys
+import pip
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
+
+if sys.version_info < (3, 5, 2):
+    sys.exit("Sorry, you need Python 3.5.2+")
+
+pip_version = int(pip.__version__.replace(".", ""))
+if pip_version < 901:
+        sys.exit("Sorry, you need pip 9.0.1+")
+
 
 setup(
     name='magen_id_client',
-    version='1.1a1',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     # packages=['container_test', 'ingestion_apis',
     #          'ingestion_server'],
@@ -13,7 +27,7 @@ setup(
         'responses>=0.8.1',
         'Sphinx>=1.5.1',
         'wheel>=0.30.0a0',
-        'magen_rest_service>=1.1a1',
+        'magen_rest_service>=1.1a',
     ],
     include_package_data=True,
     package_data={

--- a/magen_logaru/Makefile
+++ b/magen_logaru/Makefile
@@ -1,4 +1,5 @@
-WHEEL := magen_logger-1.0a1-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_logger-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_logger
 
 include ../common.mk

--- a/magen_logaru/__init__.py
+++ b/magen_logaru/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-logaru"""
+__version__ = '1.0a1'

--- a/magen_logaru/setup.py
+++ b/magen_logaru/setup.py
@@ -1,6 +1,10 @@
 import sys
 import pip
 from setuptools import setup, find_packages
+import os
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,7 +15,7 @@ if pip_version < 901:
 
 setup(
     name='magen_logger',
-    version='1.0a1',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     # packages=['container_test', 'ingestion_apis',
     #          'ingestion_server'],

--- a/magen_mongo/Makefile
+++ b/magen_mongo/Makefile
@@ -1,4 +1,5 @@
-WHEEL := magen_mongo-1.0a1-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_mongo-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_mongo
 SPHINX_DIR=docs
 

--- a/magen_mongo/__init__.py
+++ b/magen_mongo/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-mongo"""
+__version__ = '1.0a1'

--- a/magen_mongo/setup.py
+++ b/magen_mongo/setup.py
@@ -1,6 +1,10 @@
 import sys
 from setuptools import setup, find_packages
 import pip
+import os
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,7 +15,7 @@ if pip_version < 901:
 
 setup(
     name='magen_mongo',
-    version='1.0a1',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     # packages=['container_test', 'ingestion_apis',
     #          'ingestion_server'],
@@ -22,9 +26,9 @@ setup(
         'pytest>=3.1.3',
         'Sphinx>=1.6.3',
         'wheel>=0.30.0a0',
-        'magen_datastore==1.0a1',
-        'magen_logger==1.0a1',
-        'magen_utils>=1.1a2'
+        'magen_datastore>=1.0a',
+        'magen_logger>=1.0a',
+        'magen_utils>=1.2a'
       ],
     include_package_data=True,
     package_data={

--- a/magen_rest/Makefile
+++ b/magen_rest/Makefile
@@ -1,6 +1,7 @@
-WHEEL := magen_rest_service-1.2a2-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_rest_service-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_rest_service
-SPHINX_DIR=docs
+SPHINX_DIR = docs
 
 DOC_PACKAGES = magen_rest_apis tests
 

--- a/magen_rest/__init__.py
+++ b/magen_rest/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-rest"""
+__version__ = '1.2a2'

--- a/magen_rest/setup.py
+++ b/magen_rest/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 import pip
 import sys
+import os
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,7 +15,7 @@ if pip_version < 901:
 
 setup(
     name='magen_rest_service',
-    version='1.2a2',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     # packages=['container_test', 'ingestion_apis',
     #          'ingestion_server'],
@@ -25,8 +29,8 @@ setup(
         'responses>=0.8.1',
         'Sphinx>=1.6.3',
         'wheel>=0.30.0a0',
-        'magen_logger>=1.0a1',
-        'magen_utils>=1.1a2',
+        'magen_logger>=1.0a',
+        'magen_utils>=1.2a',
       ],
     include_package_data=True,
     package_data={

--- a/magen_stats/Makefile
+++ b/magen_stats/Makefile
@@ -1,6 +1,7 @@
-WHEEL := magen_statistics_service-1.0a1-py3-none-any.whl
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_statistics_service-$(wheel_version)-py3-none-any.whl
 PACKAGE_NAME = magen_statistics_service
-SPHINX_DIR=docs
+SPHINX_DIR = docs
 
 DOC_PACKAGES = magen_statistics_api magen_statistics_server tests
 

--- a/magen_stats/__init__.py
+++ b/magen_stats/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Init for magen-stats"""
+__version__ = '1.0a1'

--- a/magen_stats/setup.py
+++ b/magen_stats/setup.py
@@ -1,6 +1,11 @@
+# coding=utf-8
 import sys
 from setuptools import setup, find_packages
 import pip
+import os
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,7 +16,7 @@ if pip_version < 901:
 
 setup(
     name='magen_statistics_service',
-    version='1.0a1',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'aniso8601>=1.2.1',
@@ -24,9 +29,9 @@ setup(
         'requests>=2.13.0',
         'Sphinx>=1.6.3',
         'wheel>=0.30.0a0',
-        'magen_rest_service>=1.2a1',
-        'magen_logger>=1.0a1',
-        'magen_utils>=1.1a2'
+        'magen_rest_service>=1.2a',
+        'magen_logger>=1.0a',
+        'magen_utils>=1.2a'
       ],
     include_package_data=True,
     package_data={

--- a/magen_utils/Makefile
+++ b/magen_utils/Makefile
@@ -1,6 +1,7 @@
-WHEEL := magen_utils-1.1a2-py3-none-any.whl
-PACKAGE_NAME=magen_utils
-SPHINX_DIR=docs
+wheel_version := $(shell python3 -c 'import __init__ as version; print(version.__version__)')
+WHEEL := magen_utils-$(wheel_version)-py3-none-any.whl
+PACKAGE_NAME = magen_utils
+SPHINX_DIR = docs
 
 DOC_PACKAGES = magen_utils_apis
 

--- a/magen_utils/__init__.py
+++ b/magen_utils/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""magen utils init"""
+__version__ = '1.2a2'

--- a/magen_utils/setup.py
+++ b/magen_utils/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_packages
-import sys
+import sys, os
 import pip
+
+with open(os.path.join(os.path.dirname(__file__), '__init__.py')) as version_file:
+    exec(version_file.read())
 
 if sys.version_info < (3, 5, 2):
     sys.exit("Sorry, you need Python 3.5.2+")
@@ -11,10 +14,8 @@ if pip_version < 901:
 
 setup(
     name='magen_utils',
-    version='1.2a2',
+    version=__version__,
     packages=find_packages(exclude=['tests*']),
-    # packages=['container_test', 'ingestion_apis',
-    #          'ingestion_server'],
     install_requires=[
         'aniso8601>=1.2.1',
         'coverage>=4.4.1',


### PR DESCRIPTION
in setups I have truncated patch version for requirements: now all of magen-packages required to be >=MAJOR.MINOR[a/b/rc]

Now when want create a new version - only have to change it once inside __init__.py file. It will be automatically pulled to setup.py, Makefile and base docker image.

I suggest to use git tags when assigning new version:
```
git tag -a v$(python setup.py --version) -m 'description of version'
```
Docker build script loops through names of packages, collects their versions, creates requirements.txt file for pip,
Dockerfile adds all wheel files to container and on build pip installs all packages from requirements file